### PR TITLE
Setup code coverage with codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Install cargo-tarpaulin
         run: |
-          LINK="https://github.com/xd009642/tarpaulin/releases/download/0.18.5/cargo-tarpaulin-0.18.5-travis.tar.gz"
+          LINK="https://github.com/xd009642/tarpaulin/releases/download/0.19.1/cargo-tarpaulin-0.19.1-travis.tar.gz"
           curl -L --output tarpaulin.tar.gz "$LINK"
           tar -xzvf tarpaulin.tar.gz
           chmod +x cargo-tarpaulin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,3 +73,36 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
+
+  coverage:
+    name: coverage / stable
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Install cargo-tarpaulin
+        run: |
+          LINK="https://github.com/xd009642/tarpaulin/releases/download/0.18.5/cargo-tarpaulin-0.18.5-travis.tar.gz"
+          curl -L --output tarpaulin.tar.gz "$LINK"
+          tar -xzvf tarpaulin.tar.gz
+          chmod +x cargo-tarpaulin
+
+      - name: Run cargo-tarpaulin
+        run: ./cargo-tarpaulin tarpaulin --out Xml
+
+      - name: Upload to codecov.io
+        uses: codecov/codecov-action@v2
+        with:
+          token: ${{secrets.CODECOV_TOKEN}}
+
+      - name: Archive code coverage results
+        uses: actions/upload-artifact@v2
+        with:
+          name: code-coverage-report
+          path: cobertura.xml


### PR DESCRIPTION
This crate currently has a very high code coverage. Should we setup something like codecov to also get a badge and track coverage changes in the future? If so we just need the `CODECOV_TOKEN` secret setup on the repo @amousset 