### PR TITLE
fix: add `wrap_line` to prevent double spaces

### DIFF
--- a/src/headers/rfc2047.rs
+++ b/src/headers/rfc2047.rs
@@ -38,7 +38,7 @@ pub fn encode(mut s: &str, w: &mut EmailWriter<'_>) -> fmt::Result {
 
         if word.is_empty() {
             // No space remaining on this line, go to a new one
-            w.new_line_and_space()?;
+            w.wrap_line()?;
             continue;
         }
 

--- a/src/headers/writer.rs
+++ b/src/headers/writer.rs
@@ -63,6 +63,12 @@ impl<'a> EmailWriter<'a> {
         Ok(())
     }
 
+    /// Equivalent to resetting the number of spaces and calling `new_line_and_space()`.
+    pub fn wrap_line(&mut self) -> fmt::Result {
+        self.spaces = 0;
+        self.new_line_and_space()
+    }
+
     #[cfg(not(tarpaulin_include))]
     #[doc(hidden)]
     #[deprecated(note = "Renamed to `new_line`", since = "0.1.2")]


### PR DESCRIPTION
fix for: https://github.com/lettre/lettre/issues/949